### PR TITLE
Support of an optional "payload" parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class CanCan {
 		});
 	}
 
-	can(performer, action, target, payload) {
+	can(performer, action, target, options) {
 		return this.abilities
 			.filter(ability => this.instanceOf(performer, ability.model))
 			.filter(ability => {
@@ -58,7 +58,7 @@ class CanCan {
 			})
 			.filter(ability => {
 				if (ability.condition) {
-					return ability.condition(performer, target, payload);
+					return ability.condition(performer, target, options);
 				}
 
 				return true;

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ class CanCan {
 			})
 			.filter(ability => {
 				if (ability.condition) {
-					return ability.condition(performer, target, options);
+					return ability.condition(performer, target, options || {});
 				}
 
 				return true;

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class CanCan {
 		});
 	}
 
-	can(performer, action, target) {
+	can(performer, action, target, payload) {
 		return this.abilities
 			.filter(ability => this.instanceOf(performer, ability.model))
 			.filter(ability => {
@@ -58,7 +58,7 @@ class CanCan {
 			})
 			.filter(ability => {
 				if (ability.condition) {
-					return ability.condition(performer, target);
+					return ability.condition(performer, target, payload);
 				}
 
 				return true;

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ allow(Editor, 'manage', Post);
 allow(AdminUser, 'manage', 'all');
 ```
 
-### can(instance, action, target[, payload])
+### can(instance, action, target[, options])
 
 Checks if the action is possible on `target` by `instance`.
 
@@ -117,7 +117,7 @@ Type: `object`
 
 Target against which the action would be performed.
 
-#### payload
+#### options
 
 Type: `object`
 
@@ -132,24 +132,25 @@ const post = new Post();
 can(user, 'view', post);
 ```
 
+With the use of 'options' parameter
 ```js
-/*
- * Authorization granted depending on updated fields
- * with optional payload parameter
- * /
 const admin = new User({roles: ['administrator']});
 const moderator = new User({roles: ['moderator']});
 
-can(admin, 'update', moderator, {fields: ["roles"]}); // true
-can(moderator, 'update', moderator, {fields: ["roles", "username"]}); // false
-can(moderator, 'update', moderator, {fields: ["username"]}); // true
+can(admin, 'update', moderator, {fields: ['roles']});
+//=> return true
+can(moderator, 'update', moderator, {fields: ['roles', 'username']});
+//=> return false
+can(moderator, 'update', moderator, {fields: ['username']});
+//=> return true
 ```
 
-### cannot(instance, action, target[, payload])
+
+### cannot(instance, action, target[, options])
 
 Inverse of `.can()`.
 
-### authorize(instance, action, target[, payload])
+### authorize(instance, action, target[, options])
 
 Same as `.can()`, but throws an error instead of returning `false`.
 

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ Target against which the action would be performed.
 
 Type: `object`
 
-Additional contextual informations against which the action would be performed.
+Additional data for the rule condition.
 
 Examples:
 
@@ -134,15 +134,30 @@ can(user, 'view', post);
 
 With the use of 'options' parameter
 ```js
-const admin = new User({roles: ['administrator']});
-const moderator = new User({roles: ['moderator']});
+const admin = new User({role: 'administrator'});
+const user = new User({role: 'user'});
 
-can(admin, 'update', moderator, {fields: ['roles']});
-//=> return true
-can(moderator, 'update', moderator, {fields: ['roles', 'username']});
-//=> return false
-can(moderator, 'update', moderator, {fields: ['username']});
-//=> return true
+allow(User, 'update', User, (user, target, options) => {
+	if (user.role === 'administrator') {
+		return true;
+	}
+	
+	// Don't let regular user update their role
+	if (user.role === 'user' && options.fields.includes('role')) {
+		return false;
+	}
+	
+	return true;
+});
+
+can(admin, 'update', user, {fields: ['role']);
+//=> true
+
+can(user, 'update', user, {fields: ['username']);
+//=> true
+
+can(user, 'update', user, {fields: ['role']);
+//=> false
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ allow(Editor, 'manage', Post);
 allow(AdminUser, 'manage', 'all');
 ```
 
-### can(instance, action, target)
+### can(instance, action, target[, payload])
 
 Checks if the action is possible on `target` by `instance`.
 
@@ -117,6 +117,12 @@ Type: `object`
 
 Target against which the action would be performed.
 
+#### payload
+
+Type: `object`
+
+Additional contextual informations against which the action would be performed.
+
 Examples:
 
 ```js
@@ -126,11 +132,24 @@ const post = new Post();
 can(user, 'view', post);
 ```
 
-### cannot(instance, action, target)
+```js
+/*
+ * Authorization granted depending on updated fields
+ * with optional payload parameter
+ * /
+const admin = new User({roles: ['administrator']});
+const moderator = new User({roles: ['moderator']});
+
+can(admin, 'update', moderator, {fields: ["roles"]}); // true
+can(moderator, 'update', moderator, {fields: ["roles", "username"]}); // false
+can(moderator, 'update', moderator, {fields: ["username"]}); // true
+```
+
+### cannot(instance, action, target[, payload])
 
 Inverse of `.can()`.
 
-### authorize(instance, action, target)
+### authorize(instance, action, target[, payload])
 
 Same as `.can()`, but throws an error instead of returning `false`.
 

--- a/test.js
+++ b/test.js
@@ -198,20 +198,20 @@ test('pass options to the rule', t => {
 	const {can, allow} = cancan;
 
 	allow(User, 'update', User, (user, target, options) => {
-		const isAdministrator = user.get('roles').indexOf('administrator') !== -1;
-		const isModerator = user.get('roles').indexOf('moderator') !== -1;
+		const isAdministrator = user.get('roles').indexOf('administrator') >= 0;
+		const isModerator = user.get('roles').indexOf('moderator') >= 0;
 
-		const hasFieldsOption = (options && options.fields);
-		const hasRoleFieldUpdated = (hasFieldsOption && options.fields.indexOf('roles') !== -1);
+		const wantsToUpdateRoles = options.fields && options.fields.indexOf('roles') >= 0;
 
 		if (isAdministrator) {
 			return true;
 		}
-		if (isModerator && hasFieldsOption && !hasRoleFieldUpdated) {
-			return true;
+
+		if (isModerator && wantsToUpdateRules) {
+			return false;
 		}
 
-		return false;
+		return true;
 	});
 
 	const admin = new User({roles: ['administrator']});

--- a/test.js
+++ b/test.js
@@ -198,10 +198,10 @@ test('allow can depend of an optional payload', t => {
 	const {can, allow} = cancan;
 
 	allow(User, 'update', User, (user, target, payload) => {
-		return user.get('roles').includes('administrator') ||
+		return user.get('roles').indexOf('administrator') !== -1 ||
 			(
-				user.get('roles').includes('moderator') &&
-				payload && payload.fields && !payload.fields.includes('roles')
+				user.get('roles').indexOf('moderator') !== -1 &&
+				payload && payload.fields && payload.fields.indexOf('roles') === -1
 			);
 	});
 

--- a/test.js
+++ b/test.js
@@ -207,7 +207,7 @@ test('pass options to the rule', t => {
 			return true;
 		}
 
-		if (isModerator && wantsToUpdateRules) {
+		if (isModerator && wantsToUpdateRoles) {
 			return false;
 		}
 

--- a/test.js
+++ b/test.js
@@ -193,16 +193,25 @@ test('override instanceOf', t => {
 	t.false(can(user, 'create', product));
 });
 
-test('allow can depend of an optional payload', t => {
+test('pass options to the rule', t => {
 	const cancan = new CanCan();
 	const {can, allow} = cancan;
 
-	allow(User, 'update', User, (user, target, payload) => {
-		return user.get('roles').indexOf('administrator') !== -1 ||
-			(
-				user.get('roles').indexOf('moderator') !== -1 &&
-				payload && payload.fields && payload.fields.indexOf('roles') === -1
-			);
+	allow(User, 'update', User, (user, target, options) => {
+		const isAdministrator = user.get('roles').indexOf('administrator') !== -1;
+		const isModerator = user.get('roles').indexOf('moderator') !== -1;
+
+		const hasFieldsOption = (options && options.fields);
+		const hasRoleFieldUpdated = (hasFieldsOption && options.fields.indexOf('roles') !== -1);
+
+		if (isAdministrator) {
+			return true;
+		}
+		if (isModerator && hasFieldsOption && !hasRoleFieldUpdated) {
+			return true;
+		}
+
+		return false;
 	});
 
 	const admin = new User({roles: ['administrator']});

--- a/test.js
+++ b/test.js
@@ -196,7 +196,7 @@ test('override instanceOf', t => {
 test('pass options to the rule', t => {
 	const cancan = new CanCan();
 	const {can, allow} = cancan;
-	
+
 	const admin = new User({role: 'administrator'});
 	const user = new User({role: 'user'});
 

--- a/test.js
+++ b/test.js
@@ -201,12 +201,12 @@ test('pass options to the rule', t => {
 	const user = new User({role: 'user'});
 
 	allow(User, 'update', User, (user, target, options) => {
-		if (user.role === 'administrator') {
+		if (user.get('role') === 'administrator') {
 			return true;
 		}
 
 		// Don't let regular user update their role
-		if (user.role === 'user' && options.fields.includes('role')) {
+		if (user.get('role') === 'user' && options.fields.includes('role')) {
 			return false;
 		}
 

--- a/test.js
+++ b/test.js
@@ -206,7 +206,7 @@ test('pass options to the rule', t => {
 		}
 
 		// Don't let regular user update their role
-		if (user.get('role') === 'user' && options.fields.includes('role')) {
+		if (user.get('role') === 'user' && options.fields.indexOf('role') >= 0) {
 			return false;
 		}
 


### PR DESCRIPTION
Appends an optional _payload_ parameter on **.can()** method and **condition callback passed to .allow()** method.

It makes it possible to check additional informations when it's time to decide if an action can be performed or not. For instance, on an update action, permissions can now be granted according to updated fields, as shown on the updated readme.